### PR TITLE
Added German Translation and active milliseconds

### DIFF
--- a/src/main/java/com/gitlab/indicode/fabric/paperdoll/Config.java
+++ b/src/main/java/com/gitlab/indicode/fabric/paperdoll/Config.java
@@ -15,4 +15,5 @@ public class Config implements ConfigData {
     public boolean change_swim_fly = true;
     public boolean dynamic_scale = false;
     public boolean only_activity = false;
+    public long activity_millis = 0;
 }

--- a/src/main/java/com/gitlab/indicode/fabric/paperdoll/mixin/HudMixin.java
+++ b/src/main/java/com/gitlab/indicode/fabric/paperdoll/mixin/HudMixin.java
@@ -23,23 +23,33 @@ public class HudMixin {
     @Shadow
     @Final
     private MinecraftClient client;
+    private static long lastActivityTime;
 
     @Inject(method="render", at=@At("RETURN"))
     public void render(MatrixStack matrices, float f, CallbackInfo ci) {
 
-        // Don't draw if the F3 screen is open
+        // Don't draw if the F3 screen is open or hud is hidden
         if (this.client.options.debugEnabled || this.client.options.hudHidden) {
             return;
         }
 
         Config config = PaperDoll.config;
         ClientPlayerEntity player = this.client.player;
-        
-        // Don't render if it's set to only activity
-        if (!(!config.only_activity || player.isSneaking() || player.isSprinting() || player.isSwimming() || player.handSwinging || player.isFallFlying())) {
+
+        if(player == null)
             return;
+
+        if (config.only_activity) {
+
+            if(player.isSneaking() || player.isSprinting() || player.isSwimming() || player.handSwinging || player.isFallFlying()) {
+                lastActivityTime = System.currentTimeMillis();
+            } else if(System.currentTimeMillis() - lastActivityTime > config.activity_millis) {
+                // Don't render if it's set to only activity and the activity time is over.
+                return;
+            }
         }
-        
+
+
         EntityRenderDispatcher entityRenderDispatcher = this.client.getEntityRenderDispatcher();
         MatrixStack matrixStack = new MatrixStack();
         

--- a/src/main/resources/assets/paperdoll/lang/de_de.json
+++ b/src/main/resources/assets/paperdoll/lang/de_de.json
@@ -1,0 +1,14 @@
+{
+  "text.autoconfig.paperdoll.title": "Papierpuppe",
+  "text.autoconfig.paperdoll.category.default": "Einstellungen",
+  "text.autoconfig.paperdoll.option.render_height": "Höhe der Puppe",
+  "text.autoconfig.paperdoll.option.render_width": "Breite der Puppe",
+  "text.autoconfig.paperdoll.option.rotation": "Y Rotation der Puppe",
+  "text.autoconfig.paperdoll.option.dynamic_scale": "Dynamische Skalierung",
+  "text.autoconfig.paperdoll.option.x": "X Position",
+  "text.autoconfig.paperdoll.option.y": "Y Position",
+  "text.autoconfig.paperdoll.option.only_activity": "Nur Anzeigen, wenn der Spieler aktiv ist(MCPE Style)",
+  "text.autoconfig.paperdoll.option.change_swim_fly": "Puppe verschieben, während dem Schwimmen oder Fliegen",
+  "text.autoconfig.paperdoll.option.activity_millis": "Die Anzahl an Millisekunden, in denen die Puppe aktiv bleiben soll."
+
+}

--- a/src/main/resources/assets/paperdoll/lang/en_us.json
+++ b/src/main/resources/assets/paperdoll/lang/en_us.json
@@ -8,5 +8,7 @@
   "text.autoconfig.paperdoll.option.x": "X Position",
   "text.autoconfig.paperdoll.option.y": "Y Position",
   "text.autoconfig.paperdoll.option.only_activity": "Only Display When Active(MCPE Style)",
-  "text.autoconfig.paperdoll.option.change_swim_fly": "Move Doll When Swimming of Flying"
+  "text.autoconfig.paperdoll.option.change_swim_fly": "Move Doll When Swimming of Flying",
+  "text.autoconfig.paperdoll.option.activity_millis": "The milliseconds the doll should stay"
+
 }


### PR DESCRIPTION
Added a German Translation and a new Config Variable to set the Milliseconds it takes until the player is counted as inactive.

This only works when "only_activity" is set to true.
In the current Version the Player just disappears instantly and the bedrock edition doesn't do that. You can just set it to 0 to restore the function of previous versions but I like it like that.😉

If you have concerns about the German Language;
I think the German Text is pretty "understandable" so it doesn't need external checking but you can just put it in Google Translate and it will tell you that it is okay.

I would really like to see this merged
Greetings
David